### PR TITLE
Add defender bot workflow for Linux ISO updates

### DIFF
--- a/.github/workflows/defenderbot.yml
+++ b/.github/workflows/defenderbot.yml
@@ -1,0 +1,31 @@
+name: Defender Bot Linux ISO Update
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update-linux-iso:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Update Linux ISO info
+        run: bash ./scripts/update-linux-iso-info.sh
+
+      - name: Commit changes
+        run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add linux-iso-info.txt
+            git commit -m "Update Linux ISO info"
+            git push
+          else
+            echo "No changes to commit"
+          fi

--- a/linux-iso-info.txt
+++ b/linux-iso-info.txt
@@ -1,0 +1,4 @@
+Latest Ubuntu Version: 
+ISO File: 
+Download URL: https://releases.ubuntu.com/
+Last Checked: 

--- a/scripts/update-linux-iso-info.sh
+++ b/scripts/update-linux-iso-info.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUTPUT_FILE="linux-iso-info.txt"
+
+LATEST_VERSION=$(curl -s https://releases.ubuntu.com/ | grep -Eo '[0-9]+\.[0-9]+(\.[0-9]+)?/' | sort -V | tail -n1 | tr -d '/')
+ISO_NAME=$(curl -s https://releases.ubuntu.com/${LATEST_VERSION}/ | grep -Eo 'ubuntu-[0-9.]+-desktop-amd64.iso' | head -n1)
+ISO_URL="https://releases.ubuntu.com/${LATEST_VERSION}/${ISO_NAME}"
+
+{
+  echo "Latest Ubuntu Version: ${LATEST_VERSION}"
+  echo "ISO File: ${ISO_NAME}"
+  echo "Download URL: ${ISO_URL}"
+  echo "Last Checked: $(date -u)"
+} > "${OUTPUT_FILE}"
+


### PR DESCRIPTION
## Summary
- add workflow to regularly update Linux ISO info
- add script to fetch latest Ubuntu ISO data and save to file

## Testing
- `bash -n scripts/update-linux-iso-info.sh`
- `./scripts/update-linux-iso-info.sh` *(fails: no output, likely due to network restrictions)*


------
https://chatgpt.com/codex/tasks/task_e_68bee146f998833280856712ef521440