### PR TITLE
Add defender bot workflow with proxy-aware downloads

### DIFF
--- a/.github/workflows/defender-bot.yml
+++ b/.github/workflows/defender-bot.yml
@@ -1,0 +1,15 @@
+name: Defender Bot Setup
+
+on:
+  workflow_dispatch:
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download dependencies
+        env:
+          PROXY_URL: ${{ secrets.PROXY_URL }}
+        run: |
+          bash scripts/defender-bot.sh --proxy "$PROXY_URL"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # Run-as-Administrator
+
 Run as Administrator
+
+## Defender Bot Workflow
+
+This repository contains a script and GitHub Actions workflow to download Maven, Docker, Java (JDK), and Spring Boot CLI using an optional proxy server. The script targets Linux environments.
+
+### Local Usage
+
+Run the setup script and provide a proxy if needed:
+
+```bash
+bash scripts/defender-bot.sh --proxy http://proxy.example.com:8080
+```
+
+To preview the commands without downloading files, use dry-run mode:
+
+```bash
+bash scripts/defender-bot.sh --dry-run
+```
+
+### GitHub Actions
+
+The workflow at `.github/workflows/defender-bot.yml` executes the script and reads the proxy URL from the `PROXY_URL` secret.

--- a/scripts/defender-bot.sh
+++ b/scripts/defender-bot.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Defender bot setup script to download dependencies via optional proxy.
+set -euo pipefail
+
+PROXY=""
+DRY_RUN=0
+
+usage() {
+  cat <<USAGE
+Usage: $0 [--proxy PROXY_URL] [--dry-run]
+
+Options:
+  --proxy PROXY_URL  Use the specified proxy for all downloads.
+  --dry-run          Print commands without downloading files.
+USAGE
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --proxy)
+      PROXY="$2"; shift 2;;
+    --dry-run)
+      DRY_RUN=1; shift;;
+    -h|--help)
+      usage; exit 0;;
+    *)
+      echo "Unknown option: $1" >&2; usage; exit 1;;
+  esac
+done
+
+# Generic download function using curl.
+download() {
+  local url="$1";
+  local dest="$2";
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "[DRY-RUN] Would download $url to $dest";
+    return;
+  fi
+  if [ -n "$PROXY" ]; then
+    echo "Downloading $url via proxy $PROXY";
+    curl -fL -x "$PROXY" -o "$dest" "$url";
+  else
+    echo "Downloading $url";
+    curl -fL -o "$dest" "$url";
+  fi
+}
+
+# Download URLs for required tools.
+MAVEN_URL="https://archive.apache.org/dist/maven/maven-3/3.9.6/binaries/apache-maven-3.9.6-bin.zip"
+DOCKER_URL="https://download.docker.com/linux/static/stable/x86_64/docker-24.0.5.tgz"
+JDK_URL="https://download.oracle.com/java/21/latest/jdk-21_linux-x64_bin.tar.gz"
+SPRING_URL="https://repo.spring.io/release/org/springframework/boot/spring-boot-cli/3.2.2/spring-boot-cli-3.2.2-bin.tar.gz"
+
+mkdir -p downloads
+cd downloads
+
+download "$MAVEN_URL" maven.zip
+download "$DOCKER_URL" docker.tgz
+download "$JDK_URL" jdk.tar.gz
+download "$SPRING_URL" spring-boot-cli.tgz
+
+echo "Downloads complete: $(ls)"


### PR DESCRIPTION
## Summary
- add script to download Maven, Docker, JDK, and Spring Boot CLI through an optional proxy
- add GitHub Actions workflow to run the download script
- document usage and proxy configuration in README

## Testing
- `bash scripts/defender-bot.sh --dry-run --proxy http://proxy.example.com:8080`


------
https://chatgpt.com/codex/tasks/task_e_68c02283dc3c8332bd660ce07d1c75e0