### PR TITLE
Add workflow to automate MariaDB setup and system updates

### DIFF
--- a/.github/workflows/mariadb-workflow.yml
+++ b/.github/workflows/mariadb-workflow.yml
@@ -1,0 +1,29 @@
+name: MariaDB automation
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 3 * * *'
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Update and upgrade packages
+        run: |
+          sudo apt-get update
+          sudo apt-get -y upgrade
+      - name: Install MariaDB and required packages
+        run: |
+          sudo apt-get install -y mariadb-server curl
+      - name: Create file with permissions
+        run: |
+          sudo bash -c 'echo "Workflow executed on $(date)" > /tmp/workflow.log'
+          sudo chmod 644 /tmp/workflow.log
+          sudo chown $USER:$USER /tmp/workflow.log
+      - name: Start MariaDB service
+        run: |
+          sudo systemctl start mariadb
+          sudo systemctl status mariadb --no-pager


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that updates packages, installs MariaDB, and creates example files with controlled permissions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c17027f5b4833286c0025f11e80802